### PR TITLE
Drop the lock property

### DIFF
--- a/src/MongoTransport.php
+++ b/src/MongoTransport.php
@@ -48,7 +48,6 @@ final class MongoTransport implements TransportInterface, ListableReceiverInterf
 
         $document = $this->collection->findOneAndUpdate(
             [
-                'locked' => false,
                 '$or' => [
                     [
                         'delivered_at' => null,
@@ -66,7 +65,6 @@ final class MongoTransport implements TransportInterface, ListableReceiverInterf
             ],
             [
                 '$set' => [
-                    'locked' => true,
                     'delivered_at' => new UTCDateTime($now),
                 ],
             ],
@@ -134,7 +132,6 @@ final class MongoTransport implements TransportInterface, ListableReceiverInterf
             'body' => $encodedMessage['body'],
             'headers' => json_encode($encodedMessage['headers'] ?? []),
             'queue_name' => $this->options['queue'],
-            'locked' => false,
             'created_at' => new UTCDateTime($now),
             'available_at' => new UTCDateTime($availableAt),
         ];


### PR DESCRIPTION
Having a property that declares a lock is redundant in regards to the `available_at` property. In fact, nowhere in the code that property is reverted to false so, if the transport fails to ack/reject a message, that message will be locked indefinitely.

To have the same behavior, it should be enough to set a very high redelivery timeout. Or maybe a value o `0` could be handled in a special way?

WIP since I have probably to fix stuff.