### PR TITLE
remove locked property and use a consumer_id property instead

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,4 +6,4 @@ parameters:
         - tests
     ignoreErrors:
         - '#Access to an undefined property MongoDB\\Collection::\$documents.#'
-        - '#Return type \(void\) of method class@anonymous\/tests\/Unit\/MongoTransportTest.php:232::insertOne\(\) should be compatible with return type \(MongoDB\\InsertOneResult\) of method MongoDB\\Collection::insertOne\(\)#'
+        - '#Return type \(void\) of method class@anonymous\/tests\/Unit\/MongoTransportTest.php:251::insertOne\(\) should be compatible with return type \(MongoDB\\InsertOneResult\) of method MongoDB\\Collection::insertOne\(\)#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,4 +6,4 @@ parameters:
         - tests
     ignoreErrors:
         - '#Access to an undefined property MongoDB\\Collection::\$documents.#'
-        - '#Return type \(void\) of method class@anonymous\/tests\/Unit\/MongoTransportTest.php:165::insertOne\(\) should be compatible with return type \(MongoDB\\InsertOneResult\) of method MongoDB\\Collection::insertOne\(\)#'
+        - '#Return type \(void\) of method class@anonymous\/tests\/Unit\/MongoTransportTest.php:232::insertOne\(\) should be compatible with return type \(MongoDB\\InsertOneResult\) of method MongoDB\\Collection::insertOne\(\)#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,4 +6,4 @@ parameters:
         - tests
     ignoreErrors:
         - '#Access to an undefined property MongoDB\\Collection::\$documents.#'
-        - '#Return type \(void\) of method class@anonymous\/tests\/Unit\/MongoTransportTest.php:164::insertOne\(\) should be compatible with return type \(MongoDB\\InsertOneResult\) of method MongoDB\\Collection::insertOne\(\)#'
+        - '#Return type \(void\) of method class@anonymous\/tests\/Unit\/MongoTransportTest.php:165::insertOne\(\) should be compatible with return type \(MongoDB\\InsertOneResult\) of method MongoDB\\Collection::insertOne\(\)#'

--- a/src/MongoTransport.php
+++ b/src/MongoTransport.php
@@ -8,6 +8,8 @@ use DateTime;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
+use MongoDB\Driver\WriteConcern;
+use MongoDB\Operation\FindOneAndUpdate;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
@@ -21,6 +23,9 @@ use function is_array;
 
 final class MongoTransport implements TransportInterface, ListableReceiverInterface
 {
+    /**
+     * @var Collection
+     */
     private $collection;
     /**
      * @var SerializerInterface
@@ -30,12 +35,17 @@ final class MongoTransport implements TransportInterface, ListableReceiverInterf
      * @var array
      */
     private $options;
+    /**
+     * @var string
+     */
+    private $consumerId;
 
-    public function __construct(Collection $collection, SerializerInterface $serializer, array $options = [])
+    public function __construct(Collection $collection, SerializerInterface $serializer, array $options = [], string $consumerId)
     {
         $this->serializer = $serializer;
         $this->options = $options;
         $this->collection = $collection;
+        $this->consumerId = $consumerId;
     }
 
     public function get(): iterable
@@ -48,7 +58,6 @@ final class MongoTransport implements TransportInterface, ListableReceiverInterf
 
         $document = $this->collection->findOneAndUpdate(
             [
-                'locked' => false,
                 '$or' => [
                     [
                         'delivered_at' => null,
@@ -66,7 +75,7 @@ final class MongoTransport implements TransportInterface, ListableReceiverInterf
             ],
             [
                 '$set' => [
-                    'locked' => true,
+                    'consumer_id' => $this->consumerId,
                     'delivered_at' => new UTCDateTime($now),
                 ],
             ],
@@ -74,11 +83,16 @@ final class MongoTransport implements TransportInterface, ListableReceiverInterf
                 'sort' => [
                     'available_at' => 1,
                 ],
-                'writeConcern' => ['w' => 'majority']
+                'writeConcern' => new WriteConcern(WriteConcern::MAJORITY),
+                'returnDocument' => FindOneAndUpdate::RETURN_DOCUMENT_AFTER
             ]
         );
 
         if (!is_array($document)) {
+            return [];
+        }
+
+        if ($document['consumer_id'] !== $this->consumerId) {
             return [];
         }
 
@@ -134,7 +148,6 @@ final class MongoTransport implements TransportInterface, ListableReceiverInterf
             'body' => $encodedMessage['body'],
             'headers' => json_encode($encodedMessage['headers'] ?? []),
             'queue_name' => $this->options['queue'],
-            'locked' => false,
             'created_at' => new UTCDateTime($now),
             'available_at' => new UTCDateTime($availableAt),
         ];

--- a/src/MongoTransport.php
+++ b/src/MongoTransport.php
@@ -40,8 +40,12 @@ final class MongoTransport implements TransportInterface, ListableReceiverInterf
      */
     private $consumerId;
 
-    public function __construct(Collection $collection, SerializerInterface $serializer, array $options = [], string $consumerId)
-    {
+    public function __construct(
+        Collection $collection,
+        SerializerInterface $serializer,
+        string $consumerId,
+        array $options = []
+    ) {
         $this->serializer = $serializer;
         $this->options = $options;
         $this->collection = $collection;

--- a/src/MongoTransportFactory.php
+++ b/src/MongoTransportFactory.php
@@ -60,7 +60,12 @@ class MongoTransportFactory implements TransportFactoryInterface
         $client = new Client($dsn, $uriOptions, $driverOptions);
         $collection = $client->selectCollection($configuration['database'], $configuration['collection']);
 
-        return new MongoTransport($collection, $serializer, $configuration);
+        return new MongoTransport(
+            $collection,
+            $serializer,
+            $configuration,
+            uniqid('consumer_', true)
+        );
     }
 
     public function supports(string $dsn, array $options): bool

--- a/src/MongoTransportFactory.php
+++ b/src/MongoTransportFactory.php
@@ -61,10 +61,7 @@ class MongoTransportFactory implements TransportFactoryInterface
         $collection = $client->selectCollection($configuration['database'], $configuration['collection']);
 
         return new MongoTransport(
-            $collection,
-            $serializer,
-            $configuration,
-            uniqid('consumer_', true)
+            $collection, $serializer, uniqid('consumer_', true), $configuration
         );
     }
 

--- a/tests/Unit/MongoTransportFactoryTest.php
+++ b/tests/Unit/MongoTransportFactoryTest.php
@@ -60,7 +60,7 @@ class MongoTransportFactoryTest extends TestCase
     }
 
     /**
-     * @ttest
+     * @test
      */
     public function itShouldCreateTransport(): void
     {

--- a/tests/Unit/MongoTransportTest.php
+++ b/tests/Unit/MongoTransportTest.php
@@ -36,7 +36,8 @@ class MongoTransportTest extends TestCase
             [
                 'redeliver_timeout' => 3600,
                 'queue' => 'default'
-            ]
+            ],
+            'consumer_id'
         );
 
         /** @var Envelope $envelope */
@@ -70,7 +71,7 @@ class MongoTransportTest extends TestCase
                 $this->createDocument(),
             ]);
 
-        $transport = new MongoTransport($collection, $serializer, []);
+        $transport = new MongoTransport($collection, $serializer, [], 'consumer_id');
         $collection = iterator_to_array($transport->all(2));
 
         $this->assertEquals(
@@ -91,7 +92,7 @@ class MongoTransportTest extends TestCase
         $collection->method('findOne')
             ->willReturn($document);
 
-        $transport = new MongoTransport($collection, $serializer, []);
+        $transport = new MongoTransport($collection, $serializer, [], 'consumer_id');
         $envelope = $transport->find((string)(new ObjectId()));
 
         $this->assertEquals(
@@ -112,7 +113,8 @@ class MongoTransportTest extends TestCase
             $this->createSerializer(),
             [
                 'queue' => 'default'
-            ]
+            ],
+            'consumer_id'
         );
         $envelope = $transport->send(
             (new Envelope(new HelloMessage('hello')))
@@ -129,7 +131,6 @@ class MongoTransportTest extends TestCase
             json_decode($collection->documents[0]['headers'], true)
         );
         $this->assertSame('default', $collection->documents[0]['queue_name']);
-        $this->assertFalse($collection->documents[0]['locked']);
         $this->assertInstanceOf(TransportMessageIdStamp::class, $envelope->last(TransportMessageIdStamp::class));
         $this->assertSame(
             4,
@@ -154,7 +155,7 @@ class MongoTransportTest extends TestCase
             ->method('deleteOne')
             ->with(['_id' => $documentId]);
 
-        $transport = new MongoTransport($collection, $this->createSerializer(), []);
+        $transport = new MongoTransport($collection, $this->createSerializer(), [], 'consumer_id');
         $transport->ack($envelope);
         $transport->reject($envelope);
     }
@@ -183,6 +184,7 @@ class MongoTransportTest extends TestCase
             'headers' => [
                 'type' => HelloMessage::class
             ],
+            'consumer_id' => 'consumer_id',
         ];
     }
 

--- a/tests/Unit/MongoTransportTest.php
+++ b/tests/Unit/MongoTransportTest.php
@@ -33,11 +33,11 @@ class MongoTransportTest extends TestCase
         $transport = new MongoTransport(
             $collection,
             $serializer,
+            'consumer_id',
             [
                 'redeliver_timeout' => 3600,
                 'queue' => 'default'
-            ],
-            'consumer_id'
+            ]
         );
 
         /** @var Envelope $envelope */
@@ -71,11 +71,11 @@ class MongoTransportTest extends TestCase
         $transport = new MongoTransport(
             $collection,
             $serializer,
+            'consumer_id2',
             [
                 'redeliver_timeout' => 3600,
                 'queue' => 'default'
-            ],
-            'consumer_id2'
+            ]
         );
 
         $this->assertCount(0, $transport->get());
@@ -95,11 +95,11 @@ class MongoTransportTest extends TestCase
         $transport = new MongoTransport(
             $collection,
             $serializer,
+            'consumer_id2',
             [
                 'redeliver_timeout' => 3600,
                 'queue' => 'default'
-            ],
-            'consumer_id2'
+            ]
         );
 
         $this->assertCount(0, $transport->get());
@@ -120,7 +120,12 @@ class MongoTransportTest extends TestCase
                 $this->createDocument(),
             ]);
 
-        $transport = new MongoTransport($collection, $serializer, [], 'consumer_id');
+        $transport = new MongoTransport(
+            $collection,
+            $serializer,
+            'consumer_id',
+            []
+        );
         $collection = iterator_to_array($transport->all(2));
 
         $this->assertEquals(
@@ -141,7 +146,12 @@ class MongoTransportTest extends TestCase
         $collection->method('findOne')
             ->willReturn($document);
 
-        $transport = new MongoTransport($collection, $serializer, [], 'consumer_id');
+        $transport = new MongoTransport(
+            $collection,
+            $serializer,
+            'consumer_id',
+            []
+        );
         $envelope = $transport->find((string)(new ObjectId()));
 
         $this->assertEquals(
@@ -156,13 +166,17 @@ class MongoTransportTest extends TestCase
     public function itShouldReturnNothingIfIdCouldNotBeFound(): void
     {
         $serializer = $this->createSerializer();
-        $document = $this->createDocument();
 
         $collection = $this->createMock(Collection::class);
         $collection->method('findOne')
             ->willReturn(null);
 
-        $transport = new MongoTransport($collection, $serializer, [], 'consumer_id');
+        $transport = new MongoTransport(
+            $collection,
+            $serializer,
+            'consumer_id',
+            []
+        );
         $this->assertNull($transport->find(
             (string)(new ObjectId())
         ));
@@ -178,10 +192,10 @@ class MongoTransportTest extends TestCase
         $transport = new MongoTransport(
             $collection,
             $this->createSerializer(),
+            'consumer_id',
             [
                 'queue' => 'default'
-            ],
-            'consumer_id'
+            ]
         );
         $envelope = $transport->send(
             (new Envelope(new HelloMessage('hello')))
@@ -222,7 +236,12 @@ class MongoTransportTest extends TestCase
             ->method('deleteOne')
             ->with(['_id' => $documentId]);
 
-        $transport = new MongoTransport($collection, $this->createSerializer(), [], 'consumer_id');
+        $transport = new MongoTransport(
+            $collection,
+            $this->createSerializer(),
+            'consumer_id',
+            []
+        );
         $transport->ack($envelope);
         $transport->reject($envelope);
     }


### PR DESCRIPTION
This will stop two consumers to process the same message. The idea was borrowed from @Jean85 's package: https://github.com/facile-it/mongodb-messenger-transport