### PR TITLE
Allow higher php versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "ext-json": "*",
         "symfony/messenger": "^4.0 || ^5.0",
         "mongodb/mongodb": "^1.5.2"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "emag-tech-labs/messenger-mongo-bundle",
+    "name": "trunkstar/messenger-mongo-bundle",
     "description": "A Mongo transport for the Symfony Messenger component",
     "type": "symfony-bundle",
     "license": "MIT",


### PR DESCRIPTION
Since PHP 8 is for the most part compatible with the previous version, it would be valuable to allow it as well.