### PR TITLE
Allow writeConcern to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ framework:
                     collection: hello_messages # default is "messenger_queue"
                     queue: hello_queue # default is "default"
                     redeliver_timeout: 4800 # default is 3600
+                    enable_writeConcern_majority: false # default is true
 ```
 The features described [here](https://symfony.com/doc/current/messenger.html#saving-retrying-failed-messages) can be used also, therefore the following commands are available in order to manually debug the failed messages:
 ```bash

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,4 +6,4 @@ parameters:
         - tests
     ignoreErrors:
         - '#Access to an undefined property MongoDB\\Collection::\$documents.#'
-        - '#Return type \(void\) of method class@anonymous\/tests\/Unit\/MongoTransportTest.php:251::insertOne\(\) should be compatible with return type \(MongoDB\\InsertOneResult\) of method MongoDB\\Collection::insertOne\(\)#'
+        - '#Return type \(void\) of method class@anonymous\/tests\/Unit\/MongoTransportTest.php:254::insertOne\(\) should be compatible with return type \(MongoDB\\InsertOneResult\) of method MongoDB\\Collection::insertOne\(\)#'

--- a/src/MongoTransport.php
+++ b/src/MongoTransport.php
@@ -48,6 +48,17 @@ final class MongoTransport implements TransportInterface, ListableReceiverInterf
             $this->options['redeliver_timeout']
         ));
 
+        $options = [
+            'sort' => [
+                'available_at' => 1,
+            ],
+            'returnDocument' => FindOneAndUpdate::RETURN_DOCUMENT_AFTER
+        ];
+
+        if ($this->options['enable_writeConcern_majority']) {
+            $options['writeConcern'] = new WriteConcern(WriteConcern::MAJORITY);
+        }
+
         $document = $this->collection->findOneAndUpdate(
             [
                 '$or' => [
@@ -71,13 +82,7 @@ final class MongoTransport implements TransportInterface, ListableReceiverInterf
                     'delivered_at' => new UTCDateTime($now),
                 ],
             ],
-            [
-                'sort' => [
-                    'available_at' => 1,
-                ],
-                'writeConcern' => new WriteConcern(WriteConcern::MAJORITY),
-                'returnDocument' => FindOneAndUpdate::RETURN_DOCUMENT_AFTER
-            ]
+            $options
         );
 
         if (!is_array($document)) {

--- a/src/MongoTransportFactory.php
+++ b/src/MongoTransportFactory.php
@@ -15,7 +15,8 @@ class MongoTransportFactory implements TransportFactoryInterface
     private const DEFAULT_OPTIONS = [
         'collection' => 'messenger_queue',
         'queue' => 'default',
-        'redeliver_timeout' => 3600
+        'redeliver_timeout' => 3600,
+        'enable_writeConcern_majority' => true
     ];
 
     private const DRIVER_OPTIONS_TYPE_MAP = [

--- a/tests/Unit/MongoTransportTest.php
+++ b/tests/Unit/MongoTransportTest.php
@@ -36,7 +36,8 @@ class MongoTransportTest extends TestCase
             'consumer_id',
             [
                 'redeliver_timeout' => 3600,
-                'queue' => 'default'
+                'queue' => 'default',
+                'enable_writeConcern_majority' => true
             ]
         );
 
@@ -74,7 +75,8 @@ class MongoTransportTest extends TestCase
             'consumer_id2',
             [
                 'redeliver_timeout' => 3600,
-                'queue' => 'default'
+                'queue' => 'default',
+                'enable_writeConcern_majority' => true
             ]
         );
 
@@ -98,7 +100,8 @@ class MongoTransportTest extends TestCase
             'consumer_id2',
             [
                 'redeliver_timeout' => 3600,
-                'queue' => 'default'
+                'queue' => 'default',
+                'enable_writeConcern_majority' => true
             ]
         );
 


### PR DESCRIPTION
Some server implementations don't support writeConcern, for example AWS DocumentDB Elastic Cluster.

It would be great to have the option to toggle the default writeConcern on or off.

This could also be useful to disable injection in code to instead allow custom values to be used in uriOptions.