### PR TITLE
add support for messenger:stats command added in 6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 name: CI
-on: [push, pull_request]
+on: [push]
 jobs:
     build:
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
-                php-version: ['8.1', '8.3']
+                php-version: ['8.1', '8.2', '8.3']
         name: PHP ${{ matrix.php-version }}
         steps:
             -   uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ framework:
 The features described [here](https://symfony.com/doc/current/messenger.html#saving-retrying-failed-messages) can be used also, therefore the following commands are available in order to manually debug the failed messages:
 ```bash
 # see all messages in the failure transport
-$ bin/console messenger:failed:show
+$ php bin/console messenger:failed:show
 
 # see details about a specific failed message
 $ php bin/console messenger:failed:show 20 -vv
@@ -42,8 +42,10 @@ $ php bin/console messenger:failed:retry -vv
 $ php bin/console messenger:failed:retry 20 30 --force
 
 # remove a message without retrying it
-$ bin/console messenger:failed:remove
+$ php bin/console messenger:failed:remove
+
+# displays the number of queued messages in all transports
+$ php bin/console messenger:stats
 ``` 
 ### Submitting bugs and feature requests
 If you found a nasty bug or want to propose a new feature, you're welcome to open an issue or create a pull request [here](https://github.com/eMAGTechLabs/messenger-mongo-bundle/issues). 
-

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
+        "ext-mongodb": "*",
         "symfony/messenger": "^5.0 || ^6.0 || ^7.0",
         "mongodb/mongodb": "^1.12"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,4 +6,3 @@ parameters:
         - tests
     ignoreErrors:
         - '#Access to an undefined property MongoDB\\Collection::\$documents.#'
-        - '#Return type \(void\) of method class@anonymous\/tests\/Unit\/MongoTransportTest.php:254::insertOne\(\) should be compatible with return type \(MongoDB\\InsertOneResult\) of method MongoDB\\Collection::insertOne\(\)#'

--- a/src/MongoTransport.php
+++ b/src/MongoTransport.php
@@ -16,12 +16,13 @@ use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 
 use function is_array;
 
-final class MongoTransport implements TransportInterface, ListableReceiverInterface
+final class MongoTransport implements TransportInterface, ListableReceiverInterface, MessageCountAwareInterface
 {
     private Collection $collection;
     private SerializerInterface $serializer;
@@ -201,5 +202,10 @@ final class MongoTransport implements TransportInterface, ListableReceiverInterf
         return $envelope->with(
             new TransportMessageIdStamp((string)$document['_id'])
         );
+    }
+
+    public function getMessageCount(): int
+    {
+        return $this->collection->countDocuments();
     }
 }

--- a/tests/Unit/MongoTransportFactoryTest.php
+++ b/tests/Unit/MongoTransportFactoryTest.php
@@ -6,15 +6,14 @@ namespace EmagTechLabs\MessengerMongoBundle\Tests\Unit;
 
 use EmagTechLabs\MessengerMongoBundle\MongoTransport;
 use EmagTechLabs\MessengerMongoBundle\MongoTransportFactory;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use PHPUnit\Framework\TestCase;
 
 class MongoTransportFactoryTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function itShouldSupportOnlyMongoSchema(): void
     {
         $factory = new MongoTransportFactory();
@@ -24,9 +23,7 @@ class MongoTransportFactoryTest extends TestCase
         $this->assertFalse($factory->supports('doctrine://', []));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function itShouldFailIfUriOptionsHasInvalidType(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -42,9 +39,7 @@ class MongoTransportFactoryTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function itShouldFailIfDriverOptionsHasInvalidType(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -60,9 +55,7 @@ class MongoTransportFactoryTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function itShouldCreateTransport(): void
     {
         $factory = new MongoTransportFactory();


### PR DESCRIPTION
that's it, support for the new command, `messenger:stats`, added in symfony 6.2.