### PR TITLE
- Update MongoDB library to v2.1 and adjust Composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-json": "*",
         "ext-mongodb": "*",
         "symfony/messenger": "^5.0 || ^6.0 || ^7.0",
-        "mongodb/mongodb": "^1.12"
+        "mongodb/mongodb": "^2.1"
     },
     "require-dev": {
         "symfony/serializer": "^5.0 || ^6.0 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-json": "*",
         "ext-mongodb": "*",
         "symfony/messenger": "^5.0 || ^6.0 || ^7.0",
-        "mongodb/mongodb": "^2.1"
+        "mongodb/mongodb": "^1.12 || ^2.1"
     },
     "require-dev": {
         "symfony/serializer": "^5.0 || ^6.0 || ^7.0",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update \
   && apk add --no-cache git zip make autoconf g++ openssl-dev linux-headers \
   && apk add --no-cache --virtual .build-deps $PHPIZE_DEPS
 
-RUN pecl -q install mongodb-1.17.2  \
+RUN pecl -q install mongodb-2.1.1  \
   && docker-php-ext-enable mongodb \
   && pecl -q install xdebug  \
   && docker-php-ext-enable xdebug

--- a/src/MongoTransport.php
+++ b/src/MongoTransport.php
@@ -161,7 +161,7 @@ final class MongoTransport implements TransportInterface, ListableReceiverInterf
         return $envelope->with(new TransportMessageIdStamp($objectId));
     }
 
-    public function all(int $limit = null): iterable
+    public function all(int $limit = null): \Traversable
     {
         $documents = $this->collection->find([], ['limit' => $limit]);
 


### PR DESCRIPTION
- Update Dockerfile with MongoDB extension v2.1.1
- Implement CursorInterface mock for improved test compatibility
- Refactor `all` method in `MongoTransport` to return `\Traversable`